### PR TITLE
upgraded packages to ignore force cmd

### DIFF
--- a/connections/package.json
+++ b/connections/package.json
@@ -23,7 +23,7 @@
     "@angular/router": "^15.0.0",
     "@techiediaries/ngx-qrcode": "^9.1.0",
     "@types/qrcode": "^1.5.5",
-    "angularx-qrcode": "^14.0.0",
+    "angularx-qrcode": "^15.0.1",
     "deps": "^1.0.0",
     "express": "^4.19.2",
     "html2canvas": "^1.4.1",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.0.4",
-    "@angular/cli": "~15.0.4",
+    "@angular/cli": "^15.2.11",
     "@angular/compiler-cli": "^15.0.0",
     "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/typography": "^0.5.13",


### PR DESCRIPTION
1. checkout to connections
2. delete node modules and package.lock.json
3. use npm i not npm i --force

**You should not receive dependency errors while installing packages.**