### PR TITLE
adding qrcode and html2canvas to fix warnings

### DIFF
--- a/connections/angular.json
+++ b/connections/angular.json
@@ -13,6 +13,9 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": [
+              "qrcode", "html2canvas"
+            ],
             "outputPath": "dist/connections",
             "index": "src/index.html",
             "main": "src/main.ts",


### PR DESCRIPTION
To ignore commonjs and AMD dependencies.

Warnings:-

![image](https://github.com/user-attachments/assets/f20e3c75-9c86-4553-9d70-73436536fe5c)
